### PR TITLE
Ignore any error text when finding Sphinx version.

### DIFF
--- a/cmake/common.cmake
+++ b/cmake/common.cmake
@@ -18,7 +18,7 @@ macro(build_documentation DOCUMENTATION_NAME R G B)
                     ERROR_STRIP_TRAILING_WHITESPACE)
 
     string(REGEX REPLACE "^.* " ""
-           SPHINX_VERSION "${SPHINX_OUTPUT}${SPHINX_ERROR}")
+           SPHINX_VERSION "${SPHINX_OUTPUT}")
 
     set(MINIMUM_SPHINX_VERSION 1.4)
 

--- a/cmake/common.cmake
+++ b/cmake/common.cmake
@@ -13,7 +13,6 @@ macro(build_documentation DOCUMENTATION_NAME R G B)
 
     execute_process(COMMAND ${SPHINX_EXECUTABLE} --version
                     OUTPUT_VARIABLE SPHINX_OUTPUT
-                    ERROR_VARIABLE SPHINX_ERROR
                     OUTPUT_STRIP_TRAILING_WHITESPACE
                     ERROR_STRIP_TRAILING_WHITESPACE)
 


### PR DESCRIPTION
This fixes one of the reasons for the `Sphinx 1.4 or later is required...` failures that we are seeing.

The result from `sphinx-build --version` in the `pythonplugin` branch is:
```
sphinx-build 2.2.0
C:/Users/Dave/build/OpenCOR-upstream/ext/src/plugins/thirdParty/PythonPackages/debug/lib/site-packages\site.py:26: DeprecationWarning: the imp module is deprecated in favour of importlib; see the module's documentation for alternative uses
  import imp  # Avoid import loop in Python 3
C:\Users\Dave\build\OpenCOR-upstream\ext\src\plugins\thirdParty\PythonPackages\debug\lib\site-packages\jinja2\utils.py:485: DeprecationWarning: Using or importing the ABCs from 'collections' instead of from 'collections.abc' is deprecated, and in 3.8 it will stop working
  from collections import MutableMapping
C:\Users\Dave\build\OpenCOR-upstream\ext\src\plugins\thirdParty\PythonPackages\debug\lib\site-packages\jinja2\runtime.py:318: DeprecationWarning: Using or importing the ABCs from 'collections' instead of from 'collections.abc' is deprecated, and in 3.8 it will stop working
  from collections import Mapping
```
that will cause `SPHINX_VERSION` to be set to `Mapping`.

These deprecation warnings will eventually disappear as dependent packages are upgraded but we still need to allow for possible warning messages on `stderr`.

The other failure reason could be a timing issue, with the documentation possibly being built before the PythonPackages build has finished; this is addressed by commit [2e11ac8](https://github.com/opencor/opencor/pull/2160/commits/2e11ac8d2c2ab034217d61331a508dd4bfaa4bbc).